### PR TITLE
Deployment updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,31 @@
-FROM tomcat:9
+FROM maven:3.8.6-openjdk-11 as builder
 
-RUN apt-get update
+# Install any necessary tools and updates
+RUN apt-get update && apt-get install -y \
+    unattended-upgrades \
+    apt-listchanges && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN apt-get install unattended-upgrades apt-listchanges -y
+# Set the working directory and copy project files into Docker image
+WORKDIR /usr/src/app
+COPY . /usr/src/app
 
+# Run Maven to build the project
+RUN mvn clean package
+
+# Use Tomcat base image
+FROM tomcat:9-jdk11-corretto
+
+# Copy the built WAR file from the builder stage
+COPY --from=builder /usr/src/app/target/*.war /usr/local/tomcat/webapps/
+
+# Copy the configuration and other necessary files
 COPY *.json /usr/local/tomcat/
-
 COPY gmd2geodcat.xsl /usr/local/tomcat/
-
 COPY dcat-ap-rdf2rdfa.xsl /usr/local/tomcat/
-
 COPY users.xml /usr/local/tomcat/
-
 COPY prefixes.txt /usr/local/tomcat/
-
 COPY htmlcovtemplate.txt /usr/local/tomcat/
-
 COPY htmltemplate.txt /usr/local/tomcat/
-
 COPY htmltemplate2.txt /usr/local/tomcat/
-
-COPY target/*.war /usr/local/tomcat/webapps/

--- a/README.md
+++ b/README.md
@@ -22,9 +22,15 @@ To deploy the SemanticWFS using [Docker](https://www.docker.com), you can follow
 
 * Clone the repository
 * Modify the triplestoreconf.json and wfsconf.json according to your needs
-* Build the application war file using [Maven](https://maven.apache.org)
-* Build the Docker image
-* Deploy the Docker image
+* Build the Docker image, e.g.
+```bash
+docker build . -t semanticwfs
+```
+* Deploy the Docker image, e.g.
+```bash
+docker run -p 8080:8080 semanticwfs
+```
+* Access SemanticWFS via browser at `BASE_URL/semanticwfs`
 
 A Gitlab CI workflow is included in this repository.
 

--- a/pom.xml
+++ b/pom.xml
@@ -259,8 +259,8 @@
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
             <plugin>


### PR DESCRIPTION
Building the WAR locally has resulted in a few errors for me. On the one hand, there was a mismatch of the specified Java versions (Java 11 in the POM itself and Java 8 for the Maven compiler plugin), on the other hand, it was tedious to adapt all the appropriate dependencies on my system. 

Since there is already a Docker image, I took this as an opportunity to build the WAR directly in it and then serve it via Tomcat. This allows the project to be built and worked on platform-independently.